### PR TITLE
Execute command options

### DIFF
--- a/lib/hyperkit/client/containers.rb
+++ b/lib/hyperkit/client/containers.rb
@@ -313,9 +313,9 @@ module Hyperkit
         response = post(File.join(container_path(container), "exec"), {
           command: command,
           environment: opts[:environment] || {},
-          "wait-for-websocket" => opts[:wait_for_websocket] || false,
-          interactive: opts[:interactive] || false,
-          "record-output" => opts[:record_output] || false
+          "wait-for-websocket" => options[:wait_for_websocket] || false,
+          interactive: options[:interactive] || false,
+          "record-output" => options[:record_output] || false
         }).metadata
 
         handle_async(response, options[:sync])

--- a/lib/hyperkit/client/containers.rb
+++ b/lib/hyperkit/client/containers.rb
@@ -284,6 +284,8 @@ module Hyperkit
       # @param options [Hash] Additional data to be passed
       # @option options [Hash] :environment Environment variables to set prior to command execution
       # @option options [Boolean] :sync If <code>false</code>, returns an asynchronous operation that must be passed to {Hyperkit::Client::Operations#wait_for_operation}.  If <code>true</code>, automatically waits and returns the result of the operation.  Defaults to value of {Hyperkit::Configurable#auto_sync}.
+      # @option options [Boolean] :wait_for_websocket If <code>true</code> block and wait for a websocket connection to start.
+      # @option options [Boolean] :interactive If <code>true</code>a single websocket is returned and is mapped to a pts device for stdin, stdout and stderr of the execed process. If false, three pipes will be setup, one for each of stdin, stdout and stderr.
       # @option options [Boolean] :record_output If <code>true</code>, captures the output of stdout and stderr.
       # @return [Sawyer::Resource] Operation or result, depending value of <code>:sync</code> parameter and/or {Hyperkit::Client::auto_sync}
       #

--- a/lib/hyperkit/client/containers.rb
+++ b/lib/hyperkit/client/containers.rb
@@ -313,8 +313,8 @@ module Hyperkit
         response = post(File.join(container_path(container), "exec"), {
           command: command,
           environment: opts[:environment] || {},
-          "wait-for-websocket" => false,
-          interactive: false,
+          "wait-for-websocket" => opts[:wait_for_websocket] || false,
+          interactive: opts[:interactive] || false,
           "record-output" => opts[:record_output] || false
         }).metadata
 

--- a/lib/hyperkit/client/containers.rb
+++ b/lib/hyperkit/client/containers.rb
@@ -284,6 +284,7 @@ module Hyperkit
       # @param options [Hash] Additional data to be passed
       # @option options [Hash] :environment Environment variables to set prior to command execution
       # @option options [Boolean] :sync If <code>false</code>, returns an asynchronous operation that must be passed to {Hyperkit::Client::Operations#wait_for_operation}.  If <code>true</code>, automatically waits and returns the result of the operation.  Defaults to value of {Hyperkit::Configurable#auto_sync}.
+      # @option options [Boolean] :record_output If <code>true</code>, captures the output of stdout and stderr.
       # @return [Sawyer::Resource] Operation or result, depending value of <code>:sync</code> parameter and/or {Hyperkit::Client::auto_sync}
       #
       # @example Run a command (passed as a string) in container "test-container"
@@ -313,7 +314,8 @@ module Hyperkit
           command: command,
           environment: opts[:environment] || {},
           "wait-for-websocket" => false,
-          interactive: false
+          interactive: false,
+          "record-output" => opts[:record_output] || false
         }).metadata
 
         handle_async(response, options[:sync])

--- a/spec/hyperkit/client/containers_spec.rb
+++ b/spec/hyperkit/client/containers_spec.rb
@@ -2427,6 +2427,58 @@ describe Hyperkit::Client::Containers do
 
     end
 
+    context "waiting for the websocket" do
+
+      context "when interactive is false" do
+
+        it "makes the correct API call" do
+          request = stub_post("/1.0/containers/test/exec").
+            with(body: hash_including({
+              command: ["bash", "-c", "echo \"hello world\" | tee -a /tmp/test.txt"],
+              'wait-for-websocket': true,
+              interactive: false
+            })).
+            to_return(ok_response)
+
+          client.execute_command("test", ["bash", "-c", "echo \"hello world\" | tee -a /tmp/test.txt"], sync: false, wait_for_websocket: true, interactive: false)
+          assert_requested request
+        end
+
+      end
+
+      context "when interactive is true" do
+
+        it "makes the correct API call" do
+          request = stub_post("/1.0/containers/test/exec").
+            with(body: hash_including({
+              command: ["bash", "-c", "echo \"hello world\" | tee -a /tmp/test.txt"],
+              'wait-for-websocket': true,
+              interactive: true
+            })).
+            to_return(ok_response)
+
+          client.execute_command("test", ["bash", "-c", "echo \"hello world\" | tee -a /tmp/test.txt"], sync: false, wait_for_websocket: true, interactive: true)
+          assert_requested request
+        end
+
+      end
+
+    end
+
+    context "when recording the output" do
+      it "makes the correct API call" do
+        request = stub_post("/1.0/containers/test/exec").
+          with(body: hash_including({
+            command: ["bash", "-c", "echo \"hello world\" | tee -a /tmp/test.txt"],
+            'record-output': true
+          })).
+          to_return(ok_response)
+
+        client.execute_command("test", ["bash", "-c", "echo \"hello world\" | tee -a /tmp/test.txt"], sync: false, record_output: true)
+        assert_requested request
+      end
+    end
+
     it "raises an error if the container is not running", :container do
       call = lambda { client.execute_command("test-container", "echo hello") }
       expect(call).to raise_error(Hyperkit::BadRequest)

--- a/spec/hyperkit/client/containers_spec.rb
+++ b/spec/hyperkit/client/containers_spec.rb
@@ -2435,7 +2435,7 @@ describe Hyperkit::Client::Containers do
           request = stub_post("/1.0/containers/test/exec").
             with(body: hash_including({
               command: ["bash", "-c", "echo \"hello world\" | tee -a /tmp/test.txt"],
-              'wait-for-websocket': true,
+              'wait-for-websocket' => true,
               interactive: false
             })).
             to_return(ok_response)
@@ -2452,7 +2452,7 @@ describe Hyperkit::Client::Containers do
           request = stub_post("/1.0/containers/test/exec").
             with(body: hash_including({
               command: ["bash", "-c", "echo \"hello world\" | tee -a /tmp/test.txt"],
-              'wait-for-websocket': true,
+              'wait-for-websocket' => true,
               interactive: true
             })).
             to_return(ok_response)
@@ -2470,7 +2470,7 @@ describe Hyperkit::Client::Containers do
         request = stub_post("/1.0/containers/test/exec").
           with(body: hash_including({
             command: ["bash", "-c", "echo \"hello world\" | tee -a /tmp/test.txt"],
-            'record-output': true
+            'record-output' => true
           })).
           to_return(ok_response)
 


### PR DESCRIPTION
Expose the record-output, interactive & wait-for-websocket options to execute_command, so that you can optionally enable a websocket & connect it on the client side.