### PR TITLE
Update activesupport dependency version #9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
+  - 2.2.2 # required by 'activesupport' >= 5.0.0
+  - 2.3
+  - 2.4
+  - 2.4.2 # embedded in chefdk 2.4.17
 
 bundler_args: --without development
 
@@ -17,6 +21,9 @@ matrix:
     - rvm: jruby
     - rvm: rbx-2
     - rvm: 1.9.3
+    - rvm: 2.0
+    - rvm: 2.1
+    - rvm: 2.2
 
 notifications:
   emails: true

--- a/hyperkit.gemspec
+++ b/hyperkit.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", "~> 4.2.6"
+  spec.add_dependency "activesupport", ">= 4.2.6"
   spec.add_dependency "sawyer"
   spec.add_development_dependency "bundler", "~> 1.0"
 


### PR DESCRIPTION
I have the same issue with chefdk 2.x for my project, a kitchen driver. The existing pull request, https://github.com/jeffshantz/hyperkit/pull/9, is failing due to the travis configuration so I changed that as well.