### PR TITLE
Let OpenSSL::PKey detect client key format automatically

### DIFF
--- a/lib/hyperkit/connection.rb
+++ b/lib/hyperkit/connection.rb
@@ -168,7 +168,7 @@ module Hyperkit
       end
 
       if client_key && File.exist?(client_key)
-        conn_opts[:ssl][:client_key] = OpenSSL::PKey::RSA.new(File.read(client_key))
+        conn_opts[:ssl][:client_key] = OpenSSL::PKey.read(File.read(client_key))
       end
 
       opts[:faraday] = Faraday.new(conn_opts)


### PR DESCRIPTION
Recent versions of LXD generate ECDSA keys rather than RSA keys for
client authentication, so using the `RSA` subclass of `OpenSSL::PKey` to
open them fails with the following error:

  Neither PUB key nor PRIV key: nested asn1 error (OpenSSL::PKey::RSAError)

Ruby's OpenSSL library provides a way to open any of the supported key
types, including both RSA and ECDSA, using `OpenSSL::PKey.read` [1],
which will automatically detect the format and return the subclass for
that type of key. So, in order to support both key types, we can just
use that method instead of `OpenSSL::PKey::RSA.new`.

[1]: https://ruby-doc.org/stdlib-2.6/libdoc/openssl/rdoc/OpenSSL/PKey.html#method-c-read