### PR TITLE
Add 'devices' to extract_container_options

### DIFF
--- a/lib/hyperkit/client/containers.rb
+++ b/lib/hyperkit/client/containers.rb
@@ -1031,7 +1031,7 @@ module Hyperkit
       end
 
       def extract_container_options(name, options)
-        opts = options.slice(:architecture, :profiles, :ephemeral, :config).
+        opts = options.slice(:architecture, :profiles, :ephemeral, :config, :devices).
                        merge({ name: name })
 
         opts[:config] = stringify_hash(opts[:config]) if opts[:config]


### PR DESCRIPTION
This ensures the devices hash is used for container creation and updates calls