### PR TITLE
Fix deprecation warning from Faraday

### DIFF
--- a/lib/hyperkit/middleware/follow_redirects.rb
+++ b/lib/hyperkit/middleware/follow_redirects.rb
@@ -10,7 +10,7 @@ module Hyperkit
     # Taken from Octokit, which was originally adapted from
     # https://github.com/lostisland/faraday_middleware/blob/138766e/lib/faraday_middleware/response/follow_redirects.rb
 
-    class RedirectLimitReached < Faraday::Error::ClientError
+    class RedirectLimitReached < Faraday::ClientError
       attr_reader :response
 
       def initialize(response)


### PR DESCRIPTION
Inheriting from `Faraday::Error::ClientError` is deprecated in favour of
`Faraday::ClientError` per [1] and [2]. Changing this superclass dispels a
warning message that is currently printed whenever hyperkit is used:

    NOTE: Inheriting Faraday::Error::ClientError is deprecated; use Faraday::ClientError instead. It will be removed in or after version 1.0
    Faraday::Error::ClientError.inherited called from <...>/hyperkit-1.2.0/lib/hyperkit/middleware/follow_redirects.rb:13.

[1]: https://github.com/lostisland/faraday/blob/v0.17.1/CHANGELOG.md
[2]: https://github.com/lostisland/faraday/blob/v1.0-rc1/UPGRADING.md