### PR TITLE
Fix LXD REST API URLs

### DIFF
--- a/lib/hyperkit/client/containers.rb
+++ b/lib/hyperkit/client/containers.rb
@@ -8,7 +8,7 @@ module Hyperkit
     # Methods for the containers API
     #
     # @see Hyperkit::Client
-    # @see https://github.com/lxc/lxd/blob/master/specs/rest-api.md
+    # @see https://github.com/lxc/lxd/blob/master/doc/rest-api.md
     module Containers
 
       # @!group Retrieval

--- a/lib/hyperkit/client/images.rb
+++ b/lib/hyperkit/client/images.rb
@@ -5,7 +5,7 @@ module Hyperkit
     # Methods for the images API
     #
     # @see Hyperkit::Client
-    # @see https://github.com/lxc/lxd/blob/master/specs/rest-api.md
+    # @see https://github.com/lxc/lxd/blob/master/doc/rest-api.md
     module Images
 
       # @!group Retrieval

--- a/lib/hyperkit/client/networks.rb
+++ b/lib/hyperkit/client/networks.rb
@@ -5,7 +5,7 @@ module Hyperkit
     # Methods for the networks API
     #
     # @see Hyperkit::Client
-    # @see https://github.com/lxc/lxd/blob/master/specs/rest-api.md
+    # @see https://github.com/lxc/lxd/blob/master/doc/rest-api.md
     module Networks
 
       # List of networks defined on the host
@@ -44,4 +44,3 @@ module Hyperkit
   end
 
 end
-

--- a/lib/hyperkit/client/operations.rb
+++ b/lib/hyperkit/client/operations.rb
@@ -7,7 +7,7 @@ module Hyperkit
     # Methods for the operations API
     #
     # @see Hyperkit::Client
-    # @see https://github.com/lxc/lxd/blob/master/specs/rest-api.md
+    # @see https://github.com/lxc/lxd/blob/master/doc/rest-api.md
     module Operations
 
       # List of operations active on the server
@@ -125,4 +125,3 @@ module Hyperkit
   end
 
 end
-

--- a/lib/hyperkit/client/profiles.rb
+++ b/lib/hyperkit/client/profiles.rb
@@ -7,7 +7,7 @@ module Hyperkit
     # Methods for the profiles API
     #
     # @see Hyperkit::Client
-    # @see https://github.com/lxc/lxd/blob/master/specs/rest-api.md
+    # @see https://github.com/lxc/lxd/blob/master/doc/rest-api.md
     module Profiles
 
       # List of profiles on the server


### PR DESCRIPTION
The URL in README.md was fixed in e026b68f8b582952d221b64f5a7fb5bdef29c4af, but these were likely forgotten. The previous URL no longer works.